### PR TITLE
Fix get_bulk_vector_data_by_range request format

### DIFF
--- a/src/api/vector/vector_tools.py
+++ b/src/api/vector/vector_tools.py
@@ -4,7 +4,13 @@ from typing import List, Dict, Any, Optional, Union
 from pydantic import BaseModel
 
 from ...util.registry import ToolRegistry
-from ...models.api_models import VectorIdInput, VectorLatestNInput, VectorRangeInput, BulkVectorRangeInput, DEFAULT_TRUNCATION_LIMIT
+from ...models.api_models import (
+    VectorIdInput,
+    VectorLatestNInput,
+    VectorRangeInput,
+    BulkVectorRangeInput,
+    DEFAULT_TRUNCATION_LIMIT,
+)
 from ...config import BASE_URL, TIMEOUT_MEDIUM, TIMEOUT_LARGE, VERIFY_SSL
 from ...util.logger import log_ssl_warning, log_data_validation_warning
 from ...util.truncation import truncate_response
@@ -14,7 +20,9 @@ def register_vector_tools(registry: ToolRegistry):
     """Register all vector-related API tools with the MCP server."""
 
     @registry.tool()
-    async def get_series_info_from_vector(vector_input: VectorIdInput) -> Dict[str, Any]:
+    async def get_series_info_from_vector(
+        vector_input: VectorIdInput,
+    ) -> Dict[str, Any]:
         """
         Request series metadata (productId, coordinate, titles, frequency, etc.)
         by Vector ID. Disables SSL Verification.
@@ -27,29 +35,56 @@ def register_vector_tools(registry: ToolRegistry):
             ValueError: If the API response format is unexpected or status is not SUCCESS.
             Exception: For other network or unexpected errors.
 
-        IMPORTANT: In your final response to the user, you MUST cite the source of your data. 
+        IMPORTANT: In your final response to the user, you MUST cite the source of your data.
         For series info, this means including the VectorId, ProductId (pid), and Coordinate.
         """
-        async with httpx.AsyncClient(base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False) as client:
-            log_ssl_warning("SSL verification disabled for get_series_info_from_vector.")
+        async with httpx.AsyncClient(
+            base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False
+        ) as client:
+            log_ssl_warning(
+                "SSL verification disabled for get_series_info_from_vector."
+            )
             # API expects a list containing one object
             post_data = [vector_input.model_dump()]
             try:
                 response = await client.post("/getSeriesInfoFromVector", json=post_data)
-                response.raise_for_status() # Raise exception for 4xx/5xx errors
+                response.raise_for_status()  # Raise exception for 4xx/5xx errors
                 result_list = response.json()
-                if result_list and isinstance(result_list, list) and len(result_list) > 0 and result_list[0].get("status") == "SUCCESS":
+                if (
+                    result_list
+                    and isinstance(result_list, list)
+                    and len(result_list) > 0
+                    and result_list[0].get("status") == "SUCCESS"
+                ):
                     return result_list[0].get("object", {})
                 else:
-                    api_message = result_list[0].get("object") if (result_list and isinstance(result_list, list) and len(result_list) > 0) else "Unknown API Error or Malformed Response"
-                    raise ValueError(f"API did not return SUCCESS status for vectorId {vector_input.vectorId}: {api_message}")
+                    api_message = (
+                        result_list[0].get("object")
+                        if (
+                            result_list
+                            and isinstance(result_list, list)
+                            and len(result_list) > 0
+                        )
+                        else "Unknown API Error or Malformed Response"
+                    )
+                    raise ValueError(
+                        f"API did not return SUCCESS status for vectorId {vector_input.vectorId}: {api_message}"
+                    )
             except httpx.RequestError as exc:
-                raise Exception(f"Network error calling get_series_info_from_vector: {exc}")
-            except ValueError as exc: # Catch JSON decoding errors or our own ValueErrors
-                raise ValueError(f"Error processing response for get_series_info_from_vector: {exc}")
+                raise Exception(
+                    f"Network error calling get_series_info_from_vector: {exc}"
+                )
+            except (
+                ValueError
+            ) as exc:  # Catch JSON decoding errors or our own ValueErrors
+                raise ValueError(
+                    f"Error processing response for get_series_info_from_vector: {exc}"
+                )
 
     # @registry.tool()  # Deregistered: replaced by get_sdmx_vector_data (server-side filtering)
-    async def get_data_from_vectors_and_latest_n_periods(vector_latest_n_input: VectorLatestNInput) -> Dict[str, Any]:
+    async def get_data_from_vectors_and_latest_n_periods(
+        vector_latest_n_input: VectorLatestNInput,
+    ) -> Dict[str, Any]:
         """
         Get data for the N most recent reporting periods for a specific data series
         identified by Vector ID. Disables SSL Verification.
@@ -62,29 +97,56 @@ def register_vector_tools(registry: ToolRegistry):
             ValueError: If the API response format is unexpected or status is not SUCCESS.
             Exception: For other network or unexpected errors.
 
-        IMPORTANT: In your final response to the user, you MUST cite the source of your data. 
+        IMPORTANT: In your final response to the user, you MUST cite the source of your data.
         For vector data, this means including the VectorId and Reference Period.
         """
-        async with httpx.AsyncClient(base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False) as client:
-            log_ssl_warning("SSL verification disabled for get_data_from_vectors_and_latest_n_periods.")
+        async with httpx.AsyncClient(
+            base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False
+        ) as client:
+            log_ssl_warning(
+                "SSL verification disabled for get_data_from_vectors_and_latest_n_periods."
+            )
             # API expects a list containing one object
             post_data = [vector_latest_n_input.model_dump()]
             try:
-                response = await client.post("/getDataFromVectorsAndLatestNPeriods", json=post_data)
+                response = await client.post(
+                    "/getDataFromVectorsAndLatestNPeriods", json=post_data
+                )
                 response.raise_for_status()
                 result_list = response.json()
-                if result_list and isinstance(result_list, list) and len(result_list) > 0 and result_list[0].get("status") == "SUCCESS":
+                if (
+                    result_list
+                    and isinstance(result_list, list)
+                    and len(result_list) > 0
+                    and result_list[0].get("status") == "SUCCESS"
+                ):
                     return result_list[0].get("object", {})
                 else:
-                    api_message = result_list[0].get("object") if (result_list and isinstance(result_list, list) and len(result_list) > 0) else "Unknown API Error or Malformed Response"
-                    raise ValueError(f"API did not return SUCCESS status for vectorId {vector_latest_n_input.vectorId}: {api_message}")
+                    api_message = (
+                        result_list[0].get("object")
+                        if (
+                            result_list
+                            and isinstance(result_list, list)
+                            and len(result_list) > 0
+                        )
+                        else "Unknown API Error or Malformed Response"
+                    )
+                    raise ValueError(
+                        f"API did not return SUCCESS status for vectorId {vector_latest_n_input.vectorId}: {api_message}"
+                    )
             except httpx.RequestError as exc:
-                raise Exception(f"Network error calling get_data_from_vectors_and_latest_n_periods: {exc}")
+                raise Exception(
+                    f"Network error calling get_data_from_vectors_and_latest_n_periods: {exc}"
+                )
             except ValueError as exc:
-                raise ValueError(f"Error processing response for get_data_from_vectors_and_latest_n_periods: {exc}")
+                raise ValueError(
+                    f"Error processing response for get_data_from_vectors_and_latest_n_periods: {exc}"
+                )
 
     # @registry.tool()  # Deregistered: replaced by get_sdmx_data/get_sdmx_vector_data with startPeriod/endPeriod
-    async def get_data_from_vector_by_reference_period_range(range_input: VectorRangeInput) -> List[Dict[str, Any]]:
+    async def get_data_from_vector_by_reference_period_range(
+        range_input: VectorRangeInput,
+    ) -> List[Dict[str, Any]]:
         """
         PREFERRED tool for fetching data across multiple series by reference period date range (YYYY-MM-DD).
         Accepts an array of vectorIds and retrieves all of them in a single API call.
@@ -114,8 +176,12 @@ def register_vector_tools(registry: ToolRegistry):
         IMPORTANT: In your final response to the user, you MUST cite the source of your data.
         For vector data, this means including the VectorId and Reference Period.
         """
-        async with httpx.AsyncClient(base_url=BASE_URL, timeout=TIMEOUT_LARGE, verify=False) as client: # Longer timeout
-            log_ssl_warning("SSL verification disabled for get_data_from_vector_by_reference_period_range.")
+        async with httpx.AsyncClient(
+            base_url=BASE_URL, timeout=TIMEOUT_LARGE, verify=False
+        ) as client:  # Longer timeout
+            log_ssl_warning(
+                "SSL verification disabled for get_data_from_vector_by_reference_period_range."
+            )
             # Parameters as defined in docs
             params = {
                 "vectorIds": ",".join(range_input.vectorIds),
@@ -126,9 +192,13 @@ def register_vector_tools(registry: ToolRegistry):
                 params["endReferencePeriod"] = range_input.endReferencePeriod
 
             try:
-                response = await client.get("/getDataFromVectorByReferencePeriodRange", params=params)
+                response = await client.get(
+                    "/getDataFromVectorByReferencePeriodRange", params=params
+                )
                 response.raise_for_status()
-                result_list = response.json() # API returns a list of status/object wrappers
+                result_list = (
+                    response.json()
+                )  # API returns a list of status/object wrappers
 
                 processed_data = []
                 failures = []
@@ -138,24 +208,36 @@ def register_vector_tools(registry: ToolRegistry):
                             processed_data.append(item.get("object", {}))
                         else:
                             failures.append(item)
-                            log_data_validation_warning(f"Failed to retrieve data for part of the range request: {item}")
+                            log_data_validation_warning(
+                                f"Failed to retrieve data for part of the range request: {item}"
+                            )
                 else:
-                     raise ValueError(f"API response was not a list for range request. Response: {result_list}")
+                    raise ValueError(
+                        f"API response was not a list for range request. Response: {result_list}"
+                    )
 
                 if not processed_data and failures:
-                     raise ValueError(f"API did not return SUCCESS status for any vector in range request. Failures: {failures}")
+                    raise ValueError(
+                        f"API did not return SUCCESS status for any vector in range request. Failures: {failures}"
+                    )
 
                 # Smart truncation: return a preview with pagination guidance
                 offset = range_input.offset or 0
                 limit = range_input.limit or DEFAULT_TRUNCATION_LIMIT
                 return truncate_response(processed_data, offset, limit)
             except httpx.RequestError as exc:
-                raise Exception(f"Network error calling get_data_from_vector_by_reference_period_range: {exc}")
+                raise Exception(
+                    f"Network error calling get_data_from_vector_by_reference_period_range: {exc}"
+                )
             except ValueError as exc:
-                raise ValueError(f"Error processing response for get_data_from_vector_by_reference_period_range: {exc}")
+                raise ValueError(
+                    f"Error processing response for get_data_from_vector_by_reference_period_range: {exc}"
+                )
 
     @registry.tool()
-    async def get_bulk_vector_data_by_range(bulk_range_input: BulkVectorRangeInput) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    async def get_bulk_vector_data_by_range(
+        bulk_range_input: BulkVectorRangeInput,
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         """
         Fetches bulk data for multiple vectors filtered by *release date* range (YYYY-MM-DDTHH:MM),
         NOT by reference period. Use this when you want data released within a specific
@@ -188,24 +270,34 @@ def register_vector_tools(registry: ToolRegistry):
         IMPORTANT: In your final response to the user, you MUST cite the source of your data.
         For vector data, this means including the VectorId and Release Time.
         """
-        async with httpx.AsyncClient(base_url=BASE_URL, timeout=TIMEOUT_LARGE, verify=False) as client: # Longer timeout
-            log_ssl_warning("SSL verification disabled for get_bulk_vector_data_by_range.")
-            
-            # StatCan WDS expects an array of per-vector objects:
-            # [{"vectorId": 123, "startDataPointReleaseDate": "...", "endDataPointReleaseDate": "..."}]
-            # NOT a single flat object with a vectorIds array.
-            # Do NOT set explicit Accept/Content-Type headers — httpx sets Content-Type: application/json
-            # automatically when json= is used, and a strict Accept header can itself trigger 406.
-            per_vector = {}
+        async with httpx.AsyncClient(
+            base_url=BASE_URL, timeout=TIMEOUT_LARGE, verify=False
+        ) as client:  # Longer timeout
+            log_ssl_warning(
+                "SSL verification disabled for get_bulk_vector_data_by_range."
+            )
+
+            # StatCan WDS expects a single object for bulk requests:
+            # {"vectorIds": [123, 456], "startDataPointReleaseDate": "...", "endDataPointReleaseDate": "..."}
+            post_data = {"vectorIds": bulk_range_input.vectorIds}
             if bulk_range_input.startDataPointReleaseDate:
-                per_vector["startDataPointReleaseDate"] = bulk_range_input.startDataPointReleaseDate
+                post_data["startDataPointReleaseDate"] = (
+                    bulk_range_input.startDataPointReleaseDate
+                )
             if bulk_range_input.endDataPointReleaseDate:
-                per_vector["endDataPointReleaseDate"] = bulk_range_input.endDataPointReleaseDate
-            post_data = [{"vectorId": vid, **per_vector} for vid in bulk_range_input.vectorIds]
+                post_data["endDataPointReleaseDate"] = (
+                    bulk_range_input.endDataPointReleaseDate
+                )
+
+            headers = {"Accept": "application/json", "Content-Type": "application/json"}
             try:
-                response = await client.post("/getBulkVectorDataByRange", json=post_data)
+                response = await client.post(
+                    "/getBulkVectorDataByRange", json=post_data, headers=headers
+                )
                 response.raise_for_status()
-                result_list = response.json() # API returns a list of status/object wrappers
+                result_list = (
+                    response.json()
+                )  # API returns a list of status/object wrappers
 
                 processed_data = []
                 failures = []
@@ -214,15 +306,17 @@ def register_vector_tools(registry: ToolRegistry):
                         if isinstance(item, dict) and item.get("status") == "SUCCESS":
                             # Extract the object which contains vectorId and vectorDataPoint list
                             object_data = item.get("object", {})
-                            
+
                             vector_id = object_data.get("vectorId")
                             product_id = object_data.get("productId")
                             coordinate = object_data.get("coordinate")
-                            
+
                             vector_points = object_data.get("vectorDataPoint", [])
-                            
+
                             # Flattening logic: Inject vectorId and metadata into each data point
-                            if vector_id is not None and isinstance(vector_points, list):
+                            if vector_id is not None and isinstance(
+                                vector_points, list
+                            ):
                                 for point in vector_points:
                                     if isinstance(point, dict):
                                         point["vectorId"] = vector_id
@@ -232,30 +326,44 @@ def register_vector_tools(registry: ToolRegistry):
                                             point["coordinate"] = coordinate
                                         processed_data.append(point)
                             else:
-                                 # Fallback: if structure is unexpected, just log it. 
-                                 # We don't want to break the whole batch for one weird item, 
-                                 # but we also can't insert it without a vectorId/points list.
-                                 log_data_validation_warning(f"Unexpected structure for successful vector item: {item}")
+                                # Fallback: if structure is unexpected, just log it.
+                                # We don't want to break the whole batch for one weird item,
+                                # but we also can't insert it without a vectorId/points list.
+                                log_data_validation_warning(
+                                    f"Unexpected structure for successful vector item: {item}"
+                                )
                         else:
                             failures.append(item)
-                            log_data_validation_warning(f"Failed to retrieve bulk data for part of the request: {item}")
+                            log_data_validation_warning(
+                                f"Failed to retrieve bulk data for part of the request: {item}"
+                            )
                 else:
-                     raise ValueError(f"API response was not a list for bulk request. Response: {result_list}")
+                    raise ValueError(
+                        f"API response was not a list for bulk request. Response: {result_list}"
+                    )
 
                 if not processed_data and failures:
-                    raise ValueError(f"API did not return SUCCESS status for any vector in bulk request. Failures: {failures}")
+                    raise ValueError(
+                        f"API did not return SUCCESS status for any vector in bulk request. Failures: {failures}"
+                    )
 
                 # Smart truncation: return a preview with pagination guidance
                 offset = bulk_range_input.offset or 0
                 limit = bulk_range_input.limit or DEFAULT_TRUNCATION_LIMIT
                 return truncate_response(processed_data, offset, limit)
             except httpx.RequestError as exc:
-                raise Exception(f"Network error calling get_bulk_vector_data_by_range: {exc}")
+                raise Exception(
+                    f"Network error calling get_bulk_vector_data_by_range: {exc}"
+                )
             except ValueError as exc:
-                raise ValueError(f"Error processing response for get_bulk_vector_data_by_range: {exc}")
+                raise ValueError(
+                    f"Error processing response for get_bulk_vector_data_by_range: {exc}"
+                )
 
     @registry.tool()
-    async def get_changed_series_data_from_vector(vector_input: VectorIdInput) -> Dict[str, Any]:
+    async def get_changed_series_data_from_vector(
+        vector_input: VectorIdInput,
+    ) -> Dict[str, Any]:
         """
         Get changed series data (data points that have changed) for a series
         identified by Vector ID. Disables SSL Verification.
@@ -268,26 +376,51 @@ def register_vector_tools(registry: ToolRegistry):
             ValueError: If the API response format is unexpected or status is not SUCCESS.
             Exception: For other network or unexpected errors.
 
-        IMPORTANT: In your final response to the user, you MUST cite the source of your data. 
+        IMPORTANT: In your final response to the user, you MUST cite the source of your data.
         For changed series data, this means including the VectorId.
         """
-        async with httpx.AsyncClient(base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False) as client:
-            log_ssl_warning("SSL verification disabled for get_changed_series_data_from_vector.")
+        async with httpx.AsyncClient(
+            base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False
+        ) as client:
+            log_ssl_warning(
+                "SSL verification disabled for get_changed_series_data_from_vector."
+            )
             # API expects a list containing one object
             post_data = [vector_input.model_dump()]
             try:
-                response = await client.post("/getChangedSeriesDataFromVector", json=post_data)
+                response = await client.post(
+                    "/getChangedSeriesDataFromVector", json=post_data
+                )
                 response.raise_for_status()
                 result_list = response.json()
-                if result_list and isinstance(result_list, list) and len(result_list) > 0 and result_list[0].get("status") == "SUCCESS":
+                if (
+                    result_list
+                    and isinstance(result_list, list)
+                    and len(result_list) > 0
+                    and result_list[0].get("status") == "SUCCESS"
+                ):
                     return result_list[0].get("object", {})
                 else:
-                    api_message = result_list[0].get("object") if (result_list and isinstance(result_list, list) and len(result_list) > 0) else "Unknown API Error or Malformed Response"
-                    raise ValueError(f"API did not return SUCCESS status for changed series vectorId {vector_input.vectorId}: {api_message}")
+                    api_message = (
+                        result_list[0].get("object")
+                        if (
+                            result_list
+                            and isinstance(result_list, list)
+                            and len(result_list) > 0
+                        )
+                        else "Unknown API Error or Malformed Response"
+                    )
+                    raise ValueError(
+                        f"API did not return SUCCESS status for changed series vectorId {vector_input.vectorId}: {api_message}"
+                    )
             except httpx.RequestError as exc:
-                raise Exception(f"Network error calling get_changed_series_data_from_vector: {exc}")
+                raise Exception(
+                    f"Network error calling get_changed_series_data_from_vector: {exc}"
+                )
             except ValueError as exc:
-                raise ValueError(f"Error processing response for get_changed_series_data_from_vector: {exc}")
+                raise ValueError(
+                    f"Error processing response for get_changed_series_data_from_vector: {exc}"
+                )
 
     @registry.tool()
     async def get_changed_series_list(date: str) -> List[Dict[str, Any]]:
@@ -304,27 +437,41 @@ def register_vector_tools(registry: ToolRegistry):
             ValueError: If date format is invalid or API response format is unexpected.
             Exception: For other network or unexpected errors.
 
-        IMPORTANT: In your final response to the user, you MUST cite the source of your data. 
+        IMPORTANT: In your final response to the user, you MUST cite the source of your data.
         For changed series, this means including the VectorId.
         """
         try:
-            datetime.date.fromisoformat(date) # Validate date format
+            datetime.date.fromisoformat(date)  # Validate date format
         except ValueError:
-             raise ValueError(f"Invalid date format for get_changed_series_list. Expected YYYY-MM-DD, got {date}")
+            raise ValueError(
+                f"Invalid date format for get_changed_series_list. Expected YYYY-MM-DD, got {date}"
+            )
 
-        async with httpx.AsyncClient(base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False) as client:
+        async with httpx.AsyncClient(
+            base_url=BASE_URL, timeout=TIMEOUT_MEDIUM, verify=False
+        ) as client:
             log_ssl_warning("SSL verification disabled for get_changed_series_list.")
             try:
                 response = await client.get(f"/getChangedSeriesList/{date}")
                 response.raise_for_status()
-                result = response.json() # API returns a single status/object wrapper
+                result = response.json()  # API returns a single status/object wrapper
                 if isinstance(result, dict) and result.get("status") == "SUCCESS":
                     # The 'object' contains the list of changed series
                     return result.get("object", [])
                 else:
-                    api_message = result.get("object", "Unknown API Error") if isinstance(result, dict) else "Malformed Response"
-                    raise ValueError(f"API did not return SUCCESS status for get_changed_series_list date {date}: {api_message}")
+                    api_message = (
+                        result.get("object", "Unknown API Error")
+                        if isinstance(result, dict)
+                        else "Malformed Response"
+                    )
+                    raise ValueError(
+                        f"API did not return SUCCESS status for get_changed_series_list date {date}: {api_message}"
+                    )
             except httpx.RequestError as exc:
                 raise Exception(f"Network error calling get_changed_series_list: {exc}")
-            except ValueError as exc: # Catch JSON decoding errors or our own ValueErrors
-                raise ValueError(f"Error processing response for get_changed_series_list: {exc}")
+            except (
+                ValueError
+            ) as exc:  # Catch JSON decoding errors or our own ValueErrors
+                raise ValueError(
+                    f"Error processing response for get_changed_series_list: {exc}"
+                )


### PR DESCRIPTION
## Summary
- The StatCan `getBulkVectorDataByRange` endpoint expects a single flat JSON object with an array of `vectorIds` rather than an array of individual vector objects.
- This resolves the persistent 406 Not Acceptable errors clients were experiencing.
- Also added explicit Accept and Content-Type headers for the request.