### PR TITLE
fix(registry): use src instead of uri for icon field in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -24,7 +24,7 @@
   "websiteUrl": "https://github.com/Aryan-Jhaveri/mcp-statcan",
   "icons": [
     {
-      "uri": "https://raw.githubusercontent.com/Aryan-Jhaveri/mcp-statcan/main/assets/Flag.jpg",
+      "src": "https://raw.githubusercontent.com/Aryan-Jhaveri/mcp-statcan/main/assets/Flag.jpg",
       "mimeType": "image/jpeg",
       "sizes": ["206x109"]
     }


### PR DESCRIPTION
## Summary
- MCP registry validation was failing because `server.json` used `uri` for the icon field, but the registry schema expects `src`
- Fixes the `Validate server.json` step in the publish workflow