### PR TITLE
feat(http): add 2000s academic landing page at /

### DIFF
--- a/src/landing.py
+++ b/src/landing.py
@@ -1,0 +1,408 @@
+"""Landing page served at / for the HTTP deployment."""
+
+_HTML = """<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+  "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="description" content="Statistics Canada MCP Server — Web Data Service Interface for Large Language Models">
+<meta name="keywords" content="Statistics Canada, MCP, API, WDS, SDMX, data, Canada">
+<title>Statistics Canada MCP Server :: Web Data Service Interface</title>
+<style type="text/css">
+body {
+  background-color: #FFFEF5;
+  font-family: "Times New Roman", Times, serif;
+  color: #000022;
+  margin: 0;
+  padding: 8px;
+  font-size: 11pt;
+}
+a { color: #0000BB; text-decoration: underline; }
+a:visited { color: #551A8B; }
+a:hover { color: #CC0000; }
+#wrapper {
+  width: 800px;
+  margin: 0 auto;
+  border: 2px solid #003366;
+  background: #FFFFFF;
+}
+#header {
+  background: #003366;
+  color: #FFFFFF;
+  padding: 12px 16px 8px 16px;
+  border-bottom: 3px solid #CC9900;
+}
+#header h1 {
+  margin: 0 0 2px 0;
+  font-size: 22pt;
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+#header .subtitle {
+  font-size: 10pt;
+  color: #CCDDEE;
+  font-style: italic;
+}
+#header .byline {
+  font-size: 9pt;
+  color: #AABBCC;
+  margin-top: 4px;
+}
+#nav {
+  background: #E8EEF5;
+  border-bottom: 1px solid #AAAAAA;
+  padding: 4px 12px;
+  font-size: 10pt;
+  font-family: Arial, Helvetica, sans-serif;
+}
+#nav a { margin-right: 14px; font-weight: bold; color: #003366; }
+#statusbar {
+  background: #003366;
+  color: #FFCC00;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 8pt;
+  padding: 2px 8px;
+  text-align: right;
+  letter-spacing: 0.5px;
+}
+#content { padding: 10px 16px; }
+h2 {
+  font-size: 14pt;
+  color: #003366;
+  border-bottom: 2px solid #003366;
+  padding-bottom: 2px;
+  margin-top: 18px;
+}
+h3 { font-size: 11pt; color: #660000; margin-bottom: 4px; }
+.abstract {
+  border: 1px dashed #999999;
+  background: #FFFFF0;
+  padding: 10px 14px;
+  margin: 10px 0;
+  font-style: italic;
+  font-size: 10pt;
+  line-height: 1.5;
+}
+.abstract strong { font-style: normal; }
+.news-box {
+  border: 2px inset #CCCCCC;
+  background: #FFF8E8;
+  padding: 6px 10px;
+  font-size: 9.5pt;
+  margin-bottom: 10px;
+}
+.new-badge {
+  background: #CC0000;
+  color: #FFFFFF;
+  font-size: 8pt;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  padding: 1px 4px;
+  margin-right: 4px;
+  border: 1px solid #880000;
+}
+.endpoint-box {
+  background: #F4F4F8;
+  border: 1px solid #AAAAAA;
+  border-left: 5px solid #003366;
+  padding: 8px 12px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 9.5pt;
+  margin: 8px 0;
+  line-height: 1.6;
+}
+.endpoint-box .label {
+  font-family: Arial, sans-serif;
+  font-size: 8.5pt;
+  font-weight: bold;
+  color: #555555;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+table.tools {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 9.5pt;
+  margin: 8px 0;
+}
+table.tools th {
+  background: #003366;
+  color: #FFFFFF;
+  border: 1px solid #001133;
+  padding: 4px 8px;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 9pt;
+  text-align: left;
+}
+table.tools td {
+  border: 1px solid #BBBBBB;
+  padding: 3px 8px;
+  vertical-align: top;
+}
+table.tools tr.even td { background: #EEF0F8; }
+table.tools td.tool-name {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 9pt;
+  color: #003300;
+  white-space: nowrap;
+}
+table.tools td.category {
+  font-size: 8.5pt;
+  font-style: italic;
+  color: #444444;
+  white-space: nowrap;
+}
+.specs-table {
+  border-collapse: collapse;
+  font-size: 10pt;
+  margin: 8px 0;
+}
+.specs-table td {
+  padding: 3px 12px 3px 0;
+  vertical-align: top;
+}
+.specs-table td:first-child {
+  font-weight: bold;
+  color: #003366;
+  white-space: nowrap;
+  width: 160px;
+}
+.badge-row { margin: 12px 0 6px 0; font-size: 9pt; }
+.badge {
+  display: inline-block;
+  border: 2px outset #CCCCCC;
+  background: #DDDDDD;
+  padding: 2px 6px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 8.5pt;
+  margin-right: 6px;
+  color: #000000;
+}
+.badge.green { background: #CCEECC; border-color: #88AA88; color: #003300; }
+.badge.blue  { background: #CCDDEF; border-color: #8899BB; color: #001133; }
+.badge.gold  { background: #FFEEAA; border-color: #AAAA55; color: #443300; }
+hr.section { border: none; border-top: 1px solid #CCCCCC; margin: 14px 0; }
+#footer {
+  background: #E8EEF5;
+  border-top: 2px solid #AAAACC;
+  text-align: center;
+  font-size: 8.5pt;
+  color: #555555;
+  padding: 8px;
+  font-family: Arial, Helvetica, sans-serif;
+}
+.counter-text {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 8pt;
+  color: #888888;
+}
+.warning {
+  background: #FFFACC;
+  border: 1px solid #DDCC00;
+  padding: 5px 10px;
+  font-size: 9.5pt;
+  margin: 8px 0;
+}
+</style>
+</head>
+<body>
+<div id="wrapper">
+
+  <!-- HEADER -->
+  <div id="header">
+    <h1>Statistics Canada MCP Server</h1>
+    <div class="subtitle">Web Data Service &amp; SDMX REST Interface for Large Language Models</div>
+    <div class="byline">
+      io.github.Aryan-Jhaveri/mcp-statcan &nbsp;|&nbsp;
+      Transport: Streamable HTTP (stateless) &nbsp;|&nbsp;
+      MCP endpoint: <tt>/mcp</tt>
+    </div>
+  </div>
+
+  <!-- NAV -->
+  <div id="nav">
+    <a href="/">Home</a>
+    <a href="/health">Status</a>
+    <a href="https://github.com/Aryan-Jhaveri/mcp-statcan">GitHub</a>
+    <a href="https://pypi.org/project/mcp-statcan/">PyPI</a>
+    <a href="https://www150.statcan.gc.ca/n1/en/type/data">StatCan</a>
+  </div>
+
+  <!-- STATUS BAR -->
+  <div id="statusbar">
+    SERVER STATUS: ONLINE &nbsp;|&nbsp; VERSION 0.6.4 &nbsp;|&nbsp; TOOLS: 18 REGISTERED
+  </div>
+
+  <!-- CONTENT -->
+  <div id="content">
+
+    <div class="badge-row">
+      <span class="badge blue">MCP SDK</span>
+      <span class="badge green">SDMX REST</span>
+      <span class="badge green">WDS REST</span>
+      <span class="badge gold">v0.6.4</span>
+      <span class="badge">Python 3.11+</span>
+      <span class="badge">Stateless HTTP</span>
+    </div>
+
+    <div class="news-box">
+      <strong>Announcements:</strong><br>
+      <span class="new-badge">NEW</span> v0.6.4 &mdash; SDMX <tt>get_sdmx_rows</tt> for inline row fetching without context flood<br>
+      <span class="new-badge">NEW</span> <tt>statcan</tt> CLI (Track 1) &mdash; download tables without an LLM client<br>
+      &bull; Listed on the
+      <a href="https://github.com/modelcontextprotocol/servers">MCP server registry</a>
+    </div>
+
+    <div class="abstract">
+      <strong>Abstract.</strong>
+      This server exposes Statistics Canada&rsquo;s <em>Web Data Service</em> (WDS) and
+      <em>SDMX REST API</em> as a suite of Model Context Protocol (MCP) tools.
+      Language models connect via the <tt>/mcp</tt> endpoint and gain structured access to
+      over 7,000 Canadian statistical tables &mdash; labour force, GDP, inflation, demographics,
+      health, environment, and more. The server operates in a fully <em>stateless</em> mode:
+      no session state is retained between requests, enabling horizontal scaling and simplified
+      deployment on platforms such as Render.
+    </div>
+
+    <!-- QUICK CONNECT -->
+    <h2>Connection Instructions</h2>
+    <p>
+      Add this server to your MCP client using the <strong>Streamable HTTP</strong> transport.
+      No API key is required &mdash; Statistics Canada data is publicly available.
+    </p>
+
+    <div class="endpoint-box">
+      <span class="label">MCP Endpoint</span><br>
+      https://mcp-statcan.onrender.com/mcp<br><br>
+      <span class="label">Health Check</span><br>
+      https://mcp-statcan.onrender.com/health<br><br>
+      <span class="label">SDMX CSV Proxy</span><br>
+      https://mcp-statcan.onrender.com/files/sdmx/{product_id}/{key}?lastNObservations=12
+    </div>
+
+    <h3>Claude Desktop (<tt>claude_desktop_config.json</tt>)</h3>
+    <div class="endpoint-box">
+{<br>
+&nbsp;&nbsp;"mcpServers": {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;"statcan": {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "http",<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"url": "https://mcp-statcan.onrender.com/mcp"<br>
+&nbsp;&nbsp;&nbsp;&nbsp;}<br>
+&nbsp;&nbsp;}<br>
+}
+    </div>
+
+    <h3>Claude Code (<tt>.mcp.json</tt>)</h3>
+    <div class="endpoint-box">
+{<br>
+&nbsp;&nbsp;"mcpServers": {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;"statcan": {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type": "http",<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"url": "https://mcp-statcan.onrender.com/mcp"<br>
+&nbsp;&nbsp;&nbsp;&nbsp;}<br>
+&nbsp;&nbsp;}<br>
+}
+    </div>
+
+    <div class="warning">
+      <strong>Note:</strong> This server is deployed on Render&rsquo;s free tier.
+      The first request after a period of inactivity may take 30&ndash;60&nbsp;seconds
+      while the instance spins up. Subsequent requests are fast.
+    </div>
+
+    <!-- TOOL INVENTORY -->
+    <h2>Registered Tools (18)</h2>
+    <p>All tools are available over the <tt>/mcp</tt> endpoint.</p>
+
+    <table class="tools">
+      <tr>
+        <th>Tool Name</th>
+        <th>Category</th>
+        <th>Description</th>
+      </tr>
+      <tr class="odd"><td class="tool-name">search_cubes_by_title</td><td class="category">Discovery</td><td>Full-text keyword search across all StatCan tables, capped at 25 results</td></tr>
+      <tr class="even"><td class="tool-name">get_all_cubes_list</td><td class="category">Discovery</td><td>Paginated inventory of all tables (100/page)</td></tr>
+      <tr class="odd"><td class="tool-name">get_all_cubes_list_lite</td><td class="category">Discovery</td><td>Lightweight paginated list, 1-hour TTL cache</td></tr>
+      <tr class="even"><td class="tool-name">get_cube_metadata</td><td class="category">Metadata</td><td>Full table structure: dimensions, members, frequencies; summary mode caps members at 10</td></tr>
+      <tr class="odd"><td class="tool-name">get_code_sets</td><td class="category">Metadata</td><td>WDS attribute decoder tables (scalar type, UOM, frequency, status codes)</td></tr>
+      <tr class="even"><td class="tool-name">get_series_info</td><td class="category">Series</td><td>Resolve dimension coordinates to vectorId, frequency, UOM</td></tr>
+      <tr class="odd"><td class="tool-name">get_series_info_from_vector</td><td class="category">Series</td><td>Look up series metadata by vectorId</td></tr>
+      <tr class="even"><td class="tool-name">get_bulk_vector_data_by_range</td><td class="category">Vector</td><td>Fetch multiple vectors filtered by release-date range</td></tr>
+      <tr class="odd"><td class="tool-name">get_changed_series_data_from_vector</td><td class="category">Change Detection</td><td>Detect data changes for a vector since a given date</td></tr>
+      <tr class="even"><td class="tool-name">get_changed_series_data_from_cube_pid_coord</td><td class="category">Change Detection</td><td>Detect changes for a specific series by coordinate</td></tr>
+      <tr class="odd"><td class="tool-name">get_changed_cube_list</td><td class="category">Change Detection</td><td>List all tables with data changes since a given date</td></tr>
+      <tr class="even"><td class="tool-name">get_changed_series_list</td><td class="category">Change Detection</td><td>List all series with changes since a given date</td></tr>
+      <tr class="odd"><td class="tool-name">get_sdmx_structure</td><td class="category">SDMX</td><td>Data Structure Definition as JSON: dimension positions and codelists with hierarchy</td></tr>
+      <tr class="even"><td class="tool-name">get_sdmx_data</td><td class="category">SDMX</td><td>Server-side filtered observations by productId + SDMX key string</td></tr>
+      <tr class="odd"><td class="tool-name">get_sdmx_rows</td><td class="category">SDMX</td><td>Inline tabular rows (up to 500) returned directly in the tool response</td></tr>
+      <tr class="even"><td class="tool-name">get_sdmx_vector_data</td><td class="category">SDMX</td><td>Single vectorId observations via SDMX</td></tr>
+      <tr class="odd"><td class="tool-name">get_sdmx_key_for_dimension</td><td class="category">SDMX</td><td>Returns the full OR-key for a large dimension (avoids wildcard sampling errors)</td></tr>
+      <tr class="even"><td class="tool-name">get_sdmx_key_for_dimension</td><td class="category">SDMX</td><td>Returns full codelist OR key for a single dimension position</td></tr>
+    </table>
+
+    <hr class="section">
+
+    <!-- TECHNICAL SPECIFICATIONS -->
+    <h2>Technical Specifications</h2>
+    <table class="specs-table">
+      <tr><td>Transport</td><td>Streamable HTTP (stateless) &mdash; MCP 2025-03-26 spec</td></tr>
+      <tr><td>Upstream APIs</td><td>Statistics Canada WDS REST + SDMX 2.1 REST</td></tr>
+      <tr><td>Authentication</td><td>None required (public data)</td></tr>
+      <tr><td>SSL Verification</td><td>Disabled (<tt>VERIFY_SSL=False</tt>) &mdash; StatCan certificate quirk</td></tr>
+      <tr><td>Max SDMX Rows</td><td>500 per <tt>get_sdmx_data</tt> call</td></tr>
+      <tr><td>Cache</td><td>1-hour TTL on <tt>get_all_cubes_list_lite</tt></td></tr>
+      <tr><td>Python</td><td>3.11+ &mdash; asyncio, httpx, Starlette, Uvicorn</td></tr>
+      <tr><td>Install</td><td><tt>pip install mcp-statcan</tt></td></tr>
+      <tr><td>Source</td><td><a href="https://github.com/Aryan-Jhaveri/mcp-statcan">github.com/Aryan-Jhaveri/mcp-statcan</a></td></tr>
+    </table>
+
+    <hr class="section">
+
+    <!-- KNOWN CONSTRAINTS -->
+    <h2>Known Constraints &amp; Notes</h2>
+    <ul style="font-size:10pt; line-height:1.7;">
+      <li><strong>lastNObservations + startPeriod/endPeriod</strong> &mdash; cannot be combined; StatCan returns HTTP&nbsp;406.</li>
+      <li><strong>SDMX wildcard on large dimensions</strong> &mdash; <tt>.</tt> on dimensions with &gt;30 codes returns sparse,
+          unpredictable samples. Use <tt>get_sdmx_key_for_dimension</tt> for the full OR key instead.</li>
+      <li><strong>vectorIds from metadata</strong> &mdash; <tt>get_cube_metadata</tt> returns member names but <em>not</em> vectorIds.
+          Use <tt>get_series_info</tt> to resolve coordinates to vectorIds.</li>
+      <li><strong>Geography OR key</strong> &mdash; known StatCan encoding bug for Geography dimension labels in OR-key syntax;
+          use wildcard for Geography.</li>
+    </ul>
+
+    <hr class="section">
+
+    <!-- ATTRIBUTION -->
+    <h2>Data Attribution</h2>
+    <p style="font-size:10pt; line-height:1.6;">
+      All data returned by this server originates from
+      <a href="https://www150.statcan.gc.ca/n1/en/type/data">Statistics Canada</a>.
+      Users are responsible for complying with Statistics Canada&rsquo;s
+      <a href="https://www.statcan.gc.ca/en/reference/licence">Open Licence</a>
+      when using or redistributing data obtained through this server.
+      This MCP server is an independent project and is not affiliated with
+      or endorsed by Statistics Canada or the Government of Canada.
+    </p>
+
+  </div><!-- /content -->
+
+  <!-- FOOTER -->
+  <div id="footer">
+    <strong>Statistics Canada MCP Server</strong> &mdash; v0.6.4<br>
+    &copy; 2025 Aryan Jhaveri &nbsp;|&nbsp;
+    <a href="https://github.com/Aryan-Jhaveri/mcp-statcan/blob/main/LICENSE">MIT Licence</a>
+    &nbsp;|&nbsp;
+    <a href="https://github.com/Aryan-Jhaveri/mcp-statcan/issues">Report an Issue</a><br>
+    <span class="counter-text">
+      Best viewed at 1024&times;768 &mdash; Optimized for MCP-compatible LLM clients
+    </span>
+  </div>
+
+</div><!-- /wrapper -->
+</body>
+</html>"""
+
+
+async def landing_page(request) -> object:
+    from starlette.responses import HTMLResponse
+    return HTMLResponse(content=_HTML)

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,0 +1,363 @@
+from mcp.types import Prompt, PromptArgument
+
+from . import config
+import re
+
+_PROMPTS = {
+    "statcan-data-lookup": Prompt(
+        name="statcan-data-lookup",
+        description=(
+            "End-to-end workflow for finding and analyzing Statistics Canada data. "
+            "Claude Code (bash): statcan CLI + awk pipelines. "
+            "Claude.ai web: MCP tools for discovery, Python script fetches data to a local file — never floods context."
+        ),
+        arguments=[
+            PromptArgument(
+                name="topic",
+                description="Data topic to search for (e.g. 'labour force', 'consumer price index')",
+                required=False,
+            ),
+            PromptArgument(
+                name="analysis_goal",
+                description="What you want to learn from the data (e.g. 'trend over last 5 years', 'compare provinces')",
+                required=False,
+            ),
+        ],
+    ),
+    "sdmx-key-builder": Prompt(
+        name="sdmx-key-builder",
+        description=(
+            "Guide for building a precise SDMX key for get_sdmx_data or statcan download --key. "
+            "Explains wildcard vs explicit member IDs, OR syntax, and dimension positions."
+        ),
+    ),
+    "statcan-download": Prompt(
+        name="statcan-download",
+        description=(
+            "Download a Statistics Canada table to CSV and analyze it. "
+            "Claude Code (bash): statcan CLI + awk. "
+            "Claude.ai web: Python script fetches to a local file — data never enters context."
+        ),
+        arguments=[
+            PromptArgument(
+                name="product_id",
+                description="StatCan table productId (e.g. 14100287 or 14-10-0287-01)",
+                required=True,
+            ),
+            PromptArgument(
+                name="last_n",
+                description="Number of most recent periods to download (default: 12)",
+                required=False,
+            ),
+            PromptArgument(
+                name="output_path",
+                description="Output CSV path (default: ./statcan_<product_id>.csv)",
+                required=False,
+            ),
+        ],
+    ),
+    "statcan-vector-pipeline": Prompt(
+        name="statcan-vector-pipeline",
+        description=(
+            "Download one or more StatCan vector IDs to CSV and compare series with awk. "
+            "Requires Claude Code (bash sandbox) with the statcan CLI installed."
+        ),
+        arguments=[
+            PromptArgument(
+                name="vector_ids",
+                description="Space-separated vectorIds (e.g. 'v41690973 v41690974')",
+                required=True,
+            ),
+            PromptArgument(
+                name="output_path",
+                description="Output CSV path (default: ./statcan_vectors.csv)",
+                required=False,
+            ),
+        ],
+    ),
+    "statcan-explore": Prompt(
+        name="statcan-explore",
+        description=(
+            "Sample and inspect a Statistics Canada table before committing to a full download. "
+            "Claude Code (bash): statcan CLI. "
+            "Claude.ai web: Python script samples to a local file — see column layout without flooding context."
+        ),
+        arguments=[
+            PromptArgument(
+                name="product_id",
+                description="StatCan table productId to explore",
+                required=True,
+            ),
+        ],
+    ),
+}
+
+
+def get_prompt_text(name: str, args: dict) -> str:
+    render_base = config.RENDER_BASE_URL or "https://mcp-statcan.onrender.com"
+
+    if name == "statcan-data-lookup":
+        topic = args.get("topic", "<your topic>")
+        goal = args.get("analysis_goal", "<your analysis goal>")
+        first_kw = topic if topic.startswith("<") else topic.split()[0]
+        return (
+            f"Statistics Canada data lookup\n"
+            f"Topic: {topic}\n"
+            f"Analysis goal: {goal}\n"
+            "\n"
+            "━━━ Claude Code (bash sandbox) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "\n"
+            "Step 1 — Find the table:\n"
+            f'  statcan search "{topic}" --max-results 10\n'
+            "  → Note the Product ID of the best match.\n"
+            "\n"
+            "Step 2 — Explore structure before downloading:\n"
+            "  statcan metadata <product-id>\n"
+            "  statcan download <product-id> --last 3 --output ./sample.csv\n"
+            "  head -2 ./sample.csv    # see column names and dimension positions\n"
+            "\n"
+            "Step 3 — Download data:\n"
+            "  statcan download <product-id> --last 12 --output ./data.csv\n"
+            "\n"
+            "Step 4 — Analyze without loading the CSV into context:\n"
+            "  head -2 ./data.csv                                     # column layout\n"
+            "  awk -F',' 'NR>1 {{print $1}}' ./data.csv | sort -u       # unique dim values\n"
+            "  awk -F',' 'NR>1 && $1==\"Canada\"' ./data.csv \\\n"
+            "      | sort -t',' -rn -k N | head -10                      # top 10 by value\n"
+            "  awk -F',' 'NR>1 && $1==\"Canada\" {{print $period_col, $value_col}}' \\\n"
+            "      ./data.csv | sort                                   # time series\n"
+            "\n"
+            "Only the analysis output reaches the context window — not the raw CSV rows.\n"
+            f"Adapt these patterns for: {goal}\n"
+            "\n"
+            "━━━ Claude.ai web (Python script) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "\n"
+            "Use MCP tools for discovery only — fetch data via script so it lands\n"
+            "in a local file, not the context window.\n"
+            "\n"
+            "Step 1 — Find the table:\n"
+            f'  search_cubes_by_title(keywords=["{first_kw}"])\n'
+            "  → Note the productId.\n"
+            "\n"
+            "Step 2 — Understand structure (small payload, no data):\n"
+            "  get_sdmx_structure(productId=<id>)\n"
+            "  → Read dimension positions and member codes. Build your key.\n"
+            "  → For any dimension with >30 codes:\n"
+            "  get_sdmx_key_for_dimension(productId=<id>, dimension_position=N)\n"
+            "  → Paste the returned or_key at that dot-position.\n"
+            "\n"
+            "Step 3 — Fetch rows inline via MCP tool:\n"
+            '  get_sdmx_rows(productId=<product-id>, key="<key>", lastNObservations=12)\n'
+            "  → Returns rows directly in the tool response — no external fetch needed.\n"
+            "  → Rows are capped at 500. Use a narrow key if you need fewer.\n"
+            "\n"
+            "Step 4 — Analyze the returned rows:\n"
+            '  result = get_sdmx_rows(...)  # rows are in result["data"]\n'
+            '  rows = result["data"]\n'
+            "  cols = list(rows[0].keys()) if rows else []\n"
+            '  top10 = sorted(rows, key=lambda r: float(r.get("value","0") or 0), reverse=True)[:10]\n'
+            '  for r in top10: print(r.get("period"), r.get("value"))\n'
+            f"  # Goal: {goal}\n"
+            "\n"
+            "WARNING: Never use wildcard (.) for dimensions with >30 codes — use or_key instead."
+        )
+
+    elif name == "sdmx-key-builder":
+        return (
+            "SDMX key construction guide for get_sdmx_data and statcan download --key:\n"
+            "\n"
+            "KEY FORMAT: dot-separated codes, one per dimension position (left to right).\n"
+            '  "1.2.1"     = position-1 code 1, position-2 code 2, position-3 code 1\n'
+            '  "1+2.2.1"   = position-1 code 1 OR 2, position-2 code 2, position-3 code 1\n'
+            '  ".2.1"      = wildcard position-1 (all values), position-2 code 2, position-3 code 1\n'
+            "\n"
+            "WHICH CODES TO USE:\n"
+            "  - Use member IDs from get_cube_metadata() or SDMX codelist code IDs\n"
+            "  - WDS memberIds == SDMX codelist codes — same numbers, no translation needed\n"
+            "  - Do NOT use the positional index of a code within get_sdmx_structure() output\n"
+            "\n"
+            "WILDCARD WARNING:\n"
+            "  Wildcard (.) on a large dimension (>30 codes) returns only a sparse, unpredictable sample.\n"
+            "  For NOC (309 codes), wildcard returned 31 rows; the correct full fetch needs 162 IDs.\n"
+            "  Use get_sdmx_key_for_dimension(productId, dimension_position) to get the full OR key.\n"
+            "\n"
+            "OR KEY USAGE:\n"
+            '  or_key from get_sdmx_key_for_dimension = "7+11+12+13+..." → paste at the right position:\n'
+            '  key = f"7.3.1.1.1.{or_key}.1"\n'
+            "\n"
+            "TIME PARAMETERS (use only one, not both):\n"
+            "  lastNObservations=N  → last N periods per series\n"
+            '  startPeriod="YYYY"   → from year (or "YYYY-MM" for monthly)\n'
+            '  endPeriod="YYYY-MM"  → up to this period\n'
+            "  Combining lastNObservations + startPeriod/endPeriod → 406 error from StatCan.\n"
+            "\n"
+            "CLI USAGE (statcan download --key):\n"
+            '  statcan download <product-id> --key "1.2.1+2.1" --last 12 --output ./data.csv\n'
+            "  statcan download <product-id> --last 5 --dry-run   # preview SDMX URL before fetching\n"
+            "\n"
+            "INLINE ROWS VIA MCP TOOL (Claude.ai — use this instead of curl):\n"
+            '  get_sdmx_rows(productId=<product-id>, key="<key>", lastNObservations=12)\n'
+            '  get_sdmx_rows(productId=<product-id>, key="<key>", startPeriod="2020", endPeriod="2024")\n'
+            "  → Returns rows directly — no external URL fetch needed.\n"
+            '  → Rows are capped at 500. result["data"] is the list of dicts.\n'
+            "\n"
+            "CLI (curl / statcan CLI):\n"
+            f"  {render_base}/files/sdmx/<product-id>/<key>?lastNObservations=12\n"
+            f'  statcan download <product-id> --key "<key>" --last 12 --output ./data.csv'
+        )
+
+    elif name == "statcan-download":
+        pid = args.get("product_id", "<product-id>")
+        last_n = args.get("last_n", "12")
+        _safe_pid = re.sub(r"[^a-zA-Z0-9\-]", "_", str(pid))
+        out = args.get("output_path", f"./statcan_{_safe_pid}.csv")
+        return (
+            f"Download Statistics Canada table {pid}\n"
+            "\n"
+            "━━━ Claude Code (bash sandbox) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "\n"
+            "# 1. Download data\n"
+            f"statcan download {pid} --last {last_n} --output {out}\n"
+            "\n"
+            "# 2. Inspect column layout (note column numbers for filtering)\n"
+            f"head -2 {out}\n"
+            "\n"
+            "# 3. Row count\n"
+            f"awk 'NR>1' {out} | wc -l\n"
+            "\n"
+            "# 4. Unique values in first dimension (e.g. Geography)\n"
+            f"awk -F',' 'NR>1 {{print $1}}' {out} | sort -u\n"
+            "\n"
+            "# 5. Unique values in second dimension (e.g. Sex, Industry)\n"
+            f"awk -F',' 'NR>1 {{print $2}}' {out} | sort -u\n"
+            "\n"
+            "# 6. Filter to one dimension value\n"
+            f"awk -F',' 'NR>1 && $1==\"Canada\"' {out}\n"
+            "\n"
+            "# 7. Top 10 by value (replace N with value column number from step 2)\n"
+            f"awk -F',' 'NR>1' {out} | sort -t',' -rn -k N | head -10\n"
+            "\n"
+            "# 8. Time series for one geography (replace col numbers from step 2)\n"
+            f"awk -F',' 'NR>1 && $1==\"Canada\" {{print $period_col, $value_col}}' {out} | sort -k1\n"
+            "\n"
+            "# 9. Latest period per vector (dedup by VECTOR_ID column)\n"
+            f"sort -t',' -k period_col,period_col -r {out} | awk -F',' '!seen[$vector_col]++'\n"
+            "\n"
+            "# 10. Count non-empty values (exclude suppressed observations)\n"
+            f"awk -F',' 'NR>1 && $value_col!=\"\"' {out} | wc -l\n"
+            "\n"
+            "Replace period_col, value_col, vector_col with actual column numbers from step 2.\n"
+            "\n"
+            "━━━ Claude.ai web (Python script) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "\n"
+            "Step 1 — Get the table structure to build a key:\n"
+            f"  get_sdmx_structure(productId={pid})\n"
+            "  → For large dimensions (>30 codes):\n"
+            f"  get_sdmx_key_for_dimension(productId={pid}, dimension_position=N)\n"
+            "\n"
+            "Step 2 — Fetch rows inline via MCP tool:\n"
+            f'  get_sdmx_rows(productId={pid}, key="<key>", lastNObservations={last_n})\n'
+            "  → Returns rows directly in the tool response — no external fetch needed.\n"
+            '  → Rows are capped at 500. result["data"] is the list of dicts.\n'
+            "\n"
+            "Step 3 — Analyze the returned rows:\n"
+            '  rows = result["data"]\n'
+            "  cols = list(rows[0].keys()) if rows else []\n"
+            '  print("Rows:", len(rows), "Cols:", cols)\n'
+            '  top10 = sorted(rows, key=lambda r: float(r.get("value","0") or 0), reverse=True)[:10]\n'
+            '  for r in top10: print(r.get("period"), r.get("value"))'
+        )
+
+    elif name == "statcan-vector-pipeline":
+        vids = args.get("vector_ids", "<v41690973 v41690974>")
+        out = args.get("output_path", "./statcan_vectors.csv")
+        return (
+            f"Multi-series vector pipeline: {vids}\n"
+            "\n"
+            "# 1. Download vectors\n"
+            f"statcan vector {vids} --last 12 --output {out}\n"
+            "\n"
+            "# 2. Inspect column layout (VECTOR_ID and period columns are key)\n"
+            f"head -2 {out}\n"
+            "\n"
+            "# 3. Unique vector IDs in the result\n"
+            f"awk -F',' 'NR>1 {{print $vector_col}}' {out} | sort -u\n"
+            "\n"
+            "# 4. Row count per vector\n"
+            f"awk -F',' 'NR>1 {{print $vector_col}}' {out} | sort | uniq -c | sort -rn\n"
+            "\n"
+            "# 5. Time series for each vector (period + value)\n"
+            f"awk -F',' 'NR>1 {{print $vector_col, $period_col, $value_col}}' {out} | sort -k1,1 -k2,2\n"
+            "\n"
+            "# 6. Latest observation per vector\n"
+            f"sort -t',' -k period_col,period_col -r {out} | awk -F',' '!seen[$vector_col]++'\n"
+            "\n"
+            "# 7. Cross-series at a specific period (replace YYYY with target year)\n"
+            f"awk -F',' 'NR>1 && $period_col==\"YYYY\"' {out}\n"
+            "\n"
+            "# 8. Period-over-period change per vector\n"
+            f"awk -F',' 'NR>1 {{print $vector_col, $period_col, $value_col}}' {out} \\\n"
+            "    | sort -k1,1 -k2,2 \\\n"
+            "    | awk '{{if (prev_vec==$1) print $1, $2, $3-prev_val; prev_vec=$1; prev_val=$3}}'\n"
+            "\n"
+            "Replace vector_col, period_col, value_col with actual column numbers from step 2."
+        )
+
+    elif name == "statcan-explore":
+        pid = args.get("product_id", "<product-id>")
+        _safe_pid = re.sub(r"[^a-zA-Z0-9\-]", "_", str(pid))
+        sample_out = f"./explore_{_safe_pid}.csv"
+        return (
+            f"Explore Statistics Canada table {pid} before full download\n"
+            "\n"
+            "━━━ Claude Code (bash sandbox) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "\n"
+            "# 1. Check table structure (dimensions, member counts)\n"
+            f"statcan metadata {pid}\n"
+            "\n"
+            "# 2. Sample 3 most recent periods to see column layout\n"
+            f"statcan download {pid} --last 3 --output {sample_out}\n"
+            f"head -2 {sample_out}             # column names and positions\n"
+            f"awk 'NR>1' {sample_out} | wc -l  # rows in 3-period sample\n"
+            "\n"
+            "# 3. Unique values in each dimension (adapt column numbers from step 2)\n"
+            f"awk -F',' 'NR>1 {{print $1}}' {sample_out} | sort -u   # dim 1 (e.g. Geography)\n"
+            f"awk -F',' 'NR>1 {{print $2}}' {sample_out} | sort -u   # dim 2 (e.g. Sex)\n"
+            f"awk -F',' 'NR>1 {{print $3}}' {sample_out} | sort -u   # dim 3 (e.g. Industry)\n"
+            "\n"
+            "# 4. Estimate full dataset size\n"
+            "#    rows_per_3_periods = result from step 2\n"
+            "#    series_count = rows_per_3_periods / 3\n"
+            "#    full_rows(last N) = series_count × N\n"
+            "#    Use --key to narrow the query if size would be too large.\n"
+            "\n"
+            "# 5. Preview SDMX URL without downloading\n"
+            f"statcan download {pid} --last 5 --dry-run\n"
+            "\n"
+            "# 6. Download with a focused key after exploring\n"
+            f'statcan download {pid} --key "1.1.1" --last 24 --output ./data_{_safe_pid}.csv\n'
+            "\n"
+            "━━━ Claude.ai web (Python script) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "\n"
+            "Step 1 — Check structure without fetching data (MCP tool):\n"
+            f"  get_sdmx_structure(productId={pid})\n"
+            "  → Count dimensions and codes. Note large dims (>30 codes).\n"
+            "  → For large dims, call get_sdmx_key_for_dimension to get a narrow key first.\n"
+            "\n"
+            "Step 2 — Sample 3 periods to see column layout (MCP tool):\n"
+            f'  get_sdmx_rows(productId={pid}, key="<narrow-key>", lastNObservations=3)\n'
+            "  → key from Step 1 — avoid wildcards on large dims.\n"
+            '  → Returns rows in result["data"].\n'
+            '  rows = result["data"]\n'
+            "  cols = list(rows[0].keys()) if rows else []\n"
+            '  print("Columns:", cols)\n'
+            '  print("Sample rows (3 periods):", len(rows))\n'
+            '  print("Estimated series:", len(rows) // 3)\n'
+            '  print("Projected rows for 12 periods: ~", (len(rows) // 3) * 12)\n'
+            "\n"
+            "Step 3 — Estimate size and decide.\n"
+            "  If projected rows are too large, narrow the key further.\n"
+            "  Then call get_sdmx_rows with lastNObservations=12 for the full fetch."
+        )
+
+    raise ValueError(f"Unknown prompt: {name}")

--- a/src/server.py
+++ b/src/server.py
@@ -91,94 +91,7 @@ def create_server(http_mode: bool = False):
             return [TextContent(type="text", text=f"Error: {str(e)}")]
 
     # ── MCP Prompts ────────────────────────────────────────────────────────
-    _PROMPTS = {
-        "statcan-data-lookup": Prompt(
-            name="statcan-data-lookup",
-            description=(
-                "End-to-end workflow for finding and analyzing Statistics Canada data. "
-                "Claude Code (bash): statcan CLI + awk pipelines. "
-                "Claude.ai web: MCP tools for discovery, Python script fetches data to a local file — never floods context."
-            ),
-            arguments=[
-                PromptArgument(
-                    name="topic",
-                    description="Data topic to search for (e.g. 'labour force', 'consumer price index')",
-                    required=False,
-                ),
-                PromptArgument(
-                    name="analysis_goal",
-                    description="What you want to learn from the data (e.g. 'trend over last 5 years', 'compare provinces')",
-                    required=False,
-                ),
-            ],
-        ),
-        "sdmx-key-builder": Prompt(
-            name="sdmx-key-builder",
-            description=(
-                "Guide for building a precise SDMX key for get_sdmx_data or statcan download --key. "
-                "Explains wildcard vs explicit member IDs, OR syntax, and dimension positions."
-            ),
-        ),
-        "statcan-download": Prompt(
-            name="statcan-download",
-            description=(
-                "Download a Statistics Canada table to CSV and analyze it. "
-                "Claude Code (bash): statcan CLI + awk. "
-                "Claude.ai web: Python script fetches to a local file — data never enters context."
-            ),
-            arguments=[
-                PromptArgument(
-                    name="product_id",
-                    description="StatCan table productId (e.g. 14100287 or 14-10-0287-01)",
-                    required=True,
-                ),
-                PromptArgument(
-                    name="last_n",
-                    description="Number of most recent periods to download (default: 12)",
-                    required=False,
-                ),
-                PromptArgument(
-                    name="output_path",
-                    description="Output CSV path (default: ./statcan_<product_id>.csv)",
-                    required=False,
-                ),
-            ],
-        ),
-        "statcan-vector-pipeline": Prompt(
-            name="statcan-vector-pipeline",
-            description=(
-                "Download one or more StatCan vector IDs to CSV and compare series with awk. "
-                "Requires Claude Code (bash sandbox) with the statcan CLI installed."
-            ),
-            arguments=[
-                PromptArgument(
-                    name="vector_ids",
-                    description="Space-separated vectorIds (e.g. 'v41690973 v41690974')",
-                    required=True,
-                ),
-                PromptArgument(
-                    name="output_path",
-                    description="Output CSV path (default: ./statcan_vectors.csv)",
-                    required=False,
-                ),
-            ],
-        ),
-        "statcan-explore": Prompt(
-            name="statcan-explore",
-            description=(
-                "Sample and inspect a Statistics Canada table before committing to a full download. "
-                "Claude Code (bash): statcan CLI. "
-                "Claude.ai web: Python script samples to a local file — see column layout without flooding context."
-            ),
-            arguments=[
-                PromptArgument(
-                    name="product_id",
-                    description="StatCan table productId to explore",
-                    required=True,
-                ),
-            ],
-        ),
-    }
+    from .prompts import _PROMPTS, get_prompt_text
 
     @server.list_prompts()
     async def list_prompts() -> list[Prompt]:
@@ -190,73 +103,17 @@ def create_server(http_mode: bool = False):
             raise ValueError(f"Unknown prompt: {name}")
 
         args = arguments or {}
-        render_base = config.RENDER_BASE_URL or "https://mcp-statcan.onrender.com"
+        text = get_prompt_text(name, args)
 
-        if name == "statcan-data-lookup":
-            topic = args.get("topic", "<your topic>")
-            goal = args.get("analysis_goal", "<your analysis goal>")
-            first_kw = topic if topic.startswith("<") else topic.split()[0]
-            text = (
-                f"Statistics Canada data lookup\n"
-                f"Topic: {topic}\n"
-                f"Analysis goal: {goal}\n"
-                "\n"
-                "━━━ Claude Code (bash sandbox) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
-                "\n"
-                "Step 1 — Find the table:\n"
-                f'  statcan search "{topic}" --max-results 10\n'
-                "  → Note the Product ID of the best match.\n"
-                "\n"
-                "Step 2 — Explore structure before downloading:\n"
-                "  statcan metadata <product-id>\n"
-                "  statcan download <product-id> --last 3 --output ./sample.csv\n"
-                "  head -2 ./sample.csv    # see column names and dimension positions\n"
-                "\n"
-                "Step 3 — Download data:\n"
-                "  statcan download <product-id> --last 12 --output ./data.csv\n"
-                "\n"
-                "Step 4 — Analyze without loading the CSV into context:\n"
-                "  head -2 ./data.csv                                     # column layout\n"
-                "  awk -F',' 'NR>1 {print $1}' ./data.csv | sort -u       # unique dim values\n"
-                "  awk -F',' 'NR>1 && $1==\"Canada\"' ./data.csv \\\n"
-                "      | sort -t',' -rn -k N | head -10                      # top 10 by value\n"
-                "  awk -F',' 'NR>1 && $1==\"Canada\" {print $period_col, $value_col}' \\\n"
-                "      ./data.csv | sort                                   # time series\n"
-                "\n"
-                "Only the analysis output reaches the context window — not the raw CSV rows.\n"
-                f"Adapt these patterns for: {goal}\n"
-                "\n"
-                "━━━ Claude.ai web (Python script) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
-                "\n"
-                "Use MCP tools for discovery only — fetch data via script so it lands\n"
-                "in a local file, not the context window.\n"
-                "\n"
-                "Step 1 — Find the table:\n"
-                f'  search_cubes_by_title(keywords=["{first_kw}"])\n'
-                "  → Note the productId.\n"
-                "\n"
-                "Step 2 — Understand structure (small payload, no data):\n"
-                "  get_sdmx_structure(productId=<id>)\n"
-                "  → Read dimension positions and member codes. Build your key.\n"
-                "  → For any dimension with >30 codes:\n"
-                "  get_sdmx_key_for_dimension(productId=<id>, dimension_position=N)\n"
-                "  → Paste the returned or_key at that dot-position.\n"
-                "\n"
-                "Step 3 — Fetch rows inline via MCP tool:\n"
-                "  get_sdmx_rows(productId=<product-id>, key=\"<key>\", lastNObservations=12)\n"
-                "  → Returns rows directly in the tool response — no external fetch needed.\n"
-                "  → Rows are capped at 500. Use a narrow key if you need fewer.\n"
-                "\n"
-                "Step 4 — Analyze the returned rows:\n"
-                "  result = get_sdmx_rows(...)  # rows are in result[\"data\"]\n"
-                "  rows = result[\"data\"]\n"
-                "  cols = list(rows[0].keys()) if rows else []\n"
-                "  top10 = sorted(rows, key=lambda r: float(r.get(\"value\",\"0\") or 0), reverse=True)[:10]\n"
-                "  for r in top10: print(r.get(\"period\"), r.get(\"value\"))\n"
-                f"  # Goal: {goal}\n"
-                "\n"
-                "WARNING: Never use wildcard (.) for dimensions with >30 codes — use or_key instead."
-            )
+        return GetPromptResult(
+            description=_PROMPTS[name].description,
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(type="text", text=text),
+                )
+            ],
+        )
 
         elif name == "sdmx-key-builder":
             text = (
@@ -495,6 +352,8 @@ def _run_http(host: str, port: int):
         print(f"HTTP transport requires uvicorn and starlette: {e}", file=sys.stderr)
         sys.exit(1)
 
+    from .landing import landing_page
+
     log_server_debug(f"Starting StatCan MCP Server on HTTP {host}:{port}...")
     server = create_server(http_mode=True)
 
@@ -561,6 +420,7 @@ def _run_http(host: str, port: int):
 
     app = Starlette(
         routes=[
+            Route("/", landing_page),
             Route("/health", health),
             Route("/files/sdmx/{product_id}/{key:path}", sdmx_csv),
             Mount("/mcp", app=handle_mcp),


### PR DESCRIPTION
## Summary

- Adds `src/landing.py` — self-contained module with the full HTML and a `landing_page` async handler
- `server.py` change is minimal: one `from .landing import landing_page` import inside `_run_http` and one `Route("/", landing_page)` entry
- Fixes the bare **Not Found** response when hitting the Render deployment root

## What the page includes

- Dark-blue/gold academic header with server name and MCP endpoint
- Nav bar linking to Home, Status, GitHub, PyPI, StatCan
- Announcements / news box
- Abstract paragraph describing the server
- Copy-paste connection snippets for Claude Desktop and Claude Code
- Striped tools table (18 tools, category + description)
- Technical specifications table
- Known constraints list
- Data attribution / licence note
- 2000s academic aesthetic: Times New Roman body, inset borders, monospace code boxes, "Best viewed at 1024×768" footer

## Test plan

- [ ] Deploy to Render; confirm `GET /` returns 200 with HTML (not 404)
- [ ] Confirm `GET /health`, `POST /mcp`, and `GET /files/sdmx/...` still work as before