### PR TITLE
fix(ci): skip existing PyPI versions + bump to 0.7.0

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   publish-registry:
     needs: publish-pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src"]
 [project]
 # Core project metadata
 name = "statcan-mcp-server"
-version = "0.6.4"
+version = "0.7.0"
 description = "MCP Server for interacting with Statistics Canada Web Data Services API"
 readme = "README.md" 
 license = "MIT" 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Aryan-Jhaveri/mcp-statcan",
   "title": "Statistics Canada MCP Server",
   "description": "Access Statistics Canada data via the Web Data Services API",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "repository": {
     "url": "https://github.com/Aryan-Jhaveri/mcp-statcan",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "statcan-mcp-server",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "registryBaseUrl": "https://pypi.org",
       "runtimeHint": "uvx",
       "transport": {


### PR DESCRIPTION
## Problem

The publish workflow triggers on any `src/**` change. Non-version-bump commits (e.g. the landing page in #7) cause CI to build and re-attempt uploading the current version, failing with `400 File already exists` from PyPI.

## Changes

- `skip-existing: true` on the PyPI publish step — existing versions exit cleanly instead of erroring
- Version bump `0.6.4` → `0.7.0` in `pyproject.toml` and `server.json` (was lost during branch reset)

## Test plan

- [ ] Confirm this merge publishes `0.7.0` to PyPI successfully
- [ ] Confirm future `src/**` commits without a version bump pass CI