### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src"]
 [project]
 # Core project metadata
 name = "statcan-mcp-server"
-version = "0.7.0"
+version = "0.7.1"
 description = "MCP Server for interacting with Statistics Canada Web Data Services API"
 readme = "README.md" 
 license = "MIT" 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Aryan-Jhaveri/mcp-statcan",
   "title": "Statistics Canada MCP Server",
   "description": "Access Statistics Canada data via the Web Data Services API",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "repository": {
     "url": "https://github.com/Aryan-Jhaveri/mcp-statcan",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "statcan-mcp-server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "registryBaseUrl": "https://pypi.org",
       "runtimeHint": "uvx",
       "transport": {


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` and `server.json` from 0.7.0 → 0.7.1
- Fixes MCP registry CI failure: `cannot publish duplicate version` (0.7.0 was already published by PR #8)

## Test plan
- [ ] CI publishes 0.7.1 to PyPI and MCP registry without duplicate-version error