### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src"]
 [project]
 # Core project metadata
 name = "statcan-mcp-server"
-version = "0.7.2"
+version = "0.7.3"
 description = "MCP Server for interacting with Statistics Canada Web Data Services API"
 readme = "README.md" 
 license = "MIT" 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Aryan-Jhaveri/mcp-statcan",
   "title": "Statistics Canada MCP Server",
   "description": "Access Statistics Canada data via the Web Data Services API",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "repository": {
     "url": "https://github.com/Aryan-Jhaveri/mcp-statcan",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "statcan-mcp-server",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "registryBaseUrl": "https://pypi.org",
       "runtimeHint": "uvx",
       "transport": {

--- a/src/landing.py
+++ b/src/landing.py
@@ -224,7 +224,6 @@ hr.section { border: none; border-top: 1px solid #CCCCCC; margin: 14px 0; }
     <a href="/">Home</a>
     <a href="/health">Status</a>
     <a href="https://github.com/Aryan-Jhaveri/mcp-statcan">GitHub</a>
-    <a href="https://pypi.org/project/mcp-statcan/">PyPI</a>
     <a href="https://www150.statcan.gc.ca/n1/en/type/data">StatCan</a>
   </div>
 


### PR DESCRIPTION
Bumps version to 0.7.3 to resolve duplicate version error on MCP Registry publish.