### PR TITLE
chore: bump version to 0.7.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src"]
 [project]
 # Core project metadata
 name = "statcan-mcp-server"
-version = "0.7.4"
+version = "0.7.5"
 description = "MCP Server for interacting with Statistics Canada Web Data Services API"
 readme = "README.md" 
 license = "MIT" 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Aryan-Jhaveri/mcp-statcan",
   "title": "Statistics Canada MCP Server",
   "description": "Access Statistics Canada data via the Web Data Services API",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "repository": {
     "url": "https://github.com/Aryan-Jhaveri/mcp-statcan",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "statcan-mcp-server",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "registryBaseUrl": "https://pypi.org",
       "runtimeHint": "uvx",
       "transport": {

--- a/src/landing.py
+++ b/src/landing.py
@@ -224,7 +224,6 @@ hr.section { border: none; border-top: 1px solid #CCCCCC; margin: 14px 0; }
     <a href="/">Home</a>
     <a href="/health">Status</a>
     <a href="https://github.com/Aryan-Jhaveri/mcp-statcan">GitHub</a>
-    <a href="https://pypi.org/project/mcp-statcan/">PyPI</a>
     <a href="https://www150.statcan.gc.ca/n1/en/type/data">StatCan</a>
   </div>
 

--- a/src/landing.py
+++ b/src/landing.py
@@ -229,7 +229,7 @@ hr.section { border: none; border-top: 1px solid #CCCCCC; margin: 14px 0; }
 
   <!-- STATUS BAR -->
   <div id="statusbar">
-    SERVER STATUS: ONLINE &nbsp;|&nbsp; VERSION 0.7.2 &nbsp;|&nbsp; TOOLS: 18 REGISTERED
+    SERVER STATUS: ONLINE &nbsp;|&nbsp; VERSION 0.7.5 &nbsp;|&nbsp; TOOLS: 18 REGISTERED
   </div>
 
   <!-- CONTENT -->
@@ -239,14 +239,14 @@ hr.section { border: none; border-top: 1px solid #CCCCCC; margin: 14px 0; }
       <span class="badge blue">MCP SDK</span>
       <span class="badge green">SDMX REST</span>
       <span class="badge green">WDS REST</span>
-      <span class="badge gold">v0.7.2</span>
+      <span class="badge gold">v0.7.5</span>
       <span class="badge">Python 3.11+</span>
       <span class="badge">Stateless HTTP</span>
     </div>
 
     <div class="news-box">
       <strong>Announcements:</strong><br>
-      <span class="new-badge">NEW</span> v0.7.2 &mdash; SDMX <tt>get_sdmx_rows</tt> for inline row fetching without context flood<br>
+      <span class="new-badge">NEW</span> v0.7.5 &mdash; SDMX <tt>get_sdmx_rows</tt> for inline row fetching without context flood<br>
       <span class="new-badge">NEW</span> <tt>statcan</tt> CLI (Track 1) &mdash; download tables without an LLM client<br>
       &bull; Listed on the
       <a href="https://github.com/modelcontextprotocol/servers">MCP server registry</a>
@@ -387,7 +387,7 @@ hr.section { border: none; border-top: 1px solid #CCCCCC; margin: 14px 0; }
 
   <!-- FOOTER -->
   <div id="footer">
-    <strong>Statistics Canada MCP Server</strong> &mdash; v0.7.2<br>
+    <strong>Statistics Canada MCP Server</strong> &mdash; v0.7.5<br>
     &copy; 2025 Aryan Jhaveri &nbsp;|&nbsp;
     <a href="https://github.com/Aryan-Jhaveri/mcp-statcan/blob/main/LICENSE">MIT Licence</a>
     &nbsp;|&nbsp;


### PR DESCRIPTION
## Summary
- Bump version from `0.7.4` to `0.7.5` in `pyproject.toml`, `server.json`, and `src/landing.py`

## Files changed
- `pyproject.toml` — `version`
- `server.json` — top-level `version` + `packages[0].version`
- `src/landing.py` — statusbar, badge, news-box, footer