### PR TITLE
feat(http): add OAuth 2.1/PKCE for Claude.ai web connector tool routing

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,128 @@
+import secrets
+import time
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    RefreshToken,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+
+class PublicOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]):
+    """
+    Minimal OAuth 2.1 / PKCE provider for a fully public MCP server.
+
+    No user credentials are checked — any client that completes the PKCE
+    flow receives a valid token. The /authorize endpoint auto-approves and
+    redirects immediately so users see no login UI.
+
+    All state is in-memory and lost on restart, which is acceptable for a
+    stateless HTTP proxy. The MCP endpoint itself does NOT enforce token
+    verification; this provider exists solely to satisfy Claude.ai's
+    OAuth discovery requirement so tools are routed correctly.
+    """
+
+    def __init__(self) -> None:
+        self._clients: dict[str, OAuthClientInformationFull] = {}
+        self._auth_codes: dict[str, AuthorizationCode] = {}
+        self._access_tokens: dict[str, AccessToken] = {}
+        self._refresh_tokens: dict[str, RefreshToken] = {}
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self._clients.get(client_id)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        self._clients[client_info.client_id] = client_info
+
+    async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
+        code = secrets.token_urlsafe(32)
+        self._auth_codes[code] = AuthorizationCode(
+            code=code,
+            scopes=params.scopes or [],
+            expires_at=time.time() + 300,
+            client_id=client.client_id,
+            code_challenge=params.code_challenge,
+            redirect_uri=params.redirect_uri,
+            redirect_uri_provided_explicitly=params.redirect_uri_provided_explicitly,
+            resource=params.resource,
+        )
+        return construct_redirect_uri(str(params.redirect_uri), code=code, state=params.state)
+
+    async def load_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: str
+    ) -> AuthorizationCode | None:
+        code_obj = self._auth_codes.get(authorization_code)
+        if code_obj and code_obj.client_id == client.client_id and time.time() < code_obj.expires_at:
+            return code_obj
+        return None
+
+    async def exchange_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode
+    ) -> OAuthToken:
+        del self._auth_codes[authorization_code.code]
+        access = secrets.token_urlsafe(32)
+        refresh = secrets.token_urlsafe(32)
+        self._access_tokens[access] = AccessToken(
+            token=access,
+            client_id=client.client_id,
+            scopes=authorization_code.scopes,
+            resource=authorization_code.resource,
+        )
+        self._refresh_tokens[refresh] = RefreshToken(
+            token=refresh,
+            client_id=client.client_id,
+            scopes=authorization_code.scopes,
+        )
+        return OAuthToken(
+            access_token=access,
+            token_type="bearer",
+            refresh_token=refresh,
+            scope=" ".join(authorization_code.scopes),
+        )
+
+    async def load_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: str
+    ) -> RefreshToken | None:
+        rt = self._refresh_tokens.get(refresh_token)
+        if rt and rt.client_id == client.client_id:
+            return rt
+        return None
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        del self._refresh_tokens[refresh_token.token]
+        self._access_tokens = {
+            k: v for k, v in self._access_tokens.items() if v.client_id != client.client_id
+        }
+        effective_scopes = scopes or refresh_token.scopes
+        access = secrets.token_urlsafe(32)
+        new_refresh = secrets.token_urlsafe(32)
+        self._access_tokens[access] = AccessToken(
+            token=access, client_id=client.client_id, scopes=effective_scopes
+        )
+        self._refresh_tokens[new_refresh] = RefreshToken(
+            token=new_refresh, client_id=client.client_id, scopes=effective_scopes
+        )
+        return OAuthToken(
+            access_token=access,
+            token_type="bearer",
+            refresh_token=new_refresh,
+            scope=" ".join(effective_scopes),
+        )
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        return self._access_tokens.get(token)
+
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        if isinstance(token, AccessToken):
+            self._access_tokens.pop(token.token, None)
+        else:
+            self._refresh_tokens.pop(token.token, None)

--- a/src/server.py
+++ b/src/server.py
@@ -200,6 +200,9 @@ def _run_http(host: str, port: int):
     try:
         import uvicorn
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+        from mcp.server.auth.routes import create_auth_routes
+        from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
+        from pydantic import AnyHttpUrl
         from starlette.applications import Starlette
         from starlette.middleware.cors import CORSMiddleware
         from starlette.requests import Request
@@ -210,6 +213,7 @@ def _run_http(host: str, port: int):
         sys.exit(1)
 
     from .landing import landing_page
+    from .auth import PublicOAuthProvider
 
     log_server_debug(f"Starting StatCan MCP Server on HTTP {host}:{port}...")
     server = create_server(http_mode=True)
@@ -258,6 +262,20 @@ def _run_http(host: str, port: int):
         async with session_manager.run():
             yield
 
+    # OAuth 2.1 / PKCE — required for Claude.ai web connector tool routing.
+    # PublicOAuthProvider auto-approves all clients; no user login is shown.
+    # The MCP endpoint itself remains open (no token enforcement) so existing
+    # programmatic and Claude Desktop access is unaffected.
+    base_url = os.environ.get("RENDER_BASE_URL", f"http://localhost:{port}").rstrip("/")
+    oauth_provider = PublicOAuthProvider()
+    oauth_routes = create_auth_routes(
+        provider=oauth_provider,
+        issuer_url=AnyHttpUrl(base_url),
+        service_documentation_url=AnyHttpUrl("https://github.com/Aryan-Jhaveri/mcp-statcan"),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        revocation_options=RevocationOptions(enabled=True),
+    )
+
     # Starlette's Mount("/mcp", ...) issues a 307 redirect when the path is
     # exactly "/mcp" (no trailing slash). Many MCP clients don't follow POST
     # redirects, so they silently fail. This middleware rewrites /mcp → /mcp/
@@ -280,6 +298,7 @@ def _run_http(host: str, port: int):
             Route("/robots.txt", robots_txt),
             Route("/.well-known/mcp.json", well_known_mcp),
             Mount("/mcp", app=handle_mcp),
+            *oauth_routes,
         ],
         lifespan=lifespan,
     )


### PR DESCRIPTION
## Problem
Claude.ai web connector completes the MCP handshake (initialize → tools/list → 200 OK) but tools are never callable in conversations. Root cause: Claude.ai's web connector requires OAuth 2.1 discovery to correctly route tool calls — without it, the execution client silently drops them.

## Solution
Add a minimal public OAuth 2.1 / PKCE provider (`src/auth.py`) and wire OAuth routes into the Starlette app:

- `/.well-known/oauth-authorization-server` — OAuth metadata discovery (RFC 8414)
- `/authorize` — auto-approves all requests, redirects immediately (no login UI)
- `/token` — issues bearer tokens after PKCE verification
- `/register` — dynamic client registration (RFC 7591, required by Claude.ai)
- `/revoke` — token revocation

**No credentials are required** — `PublicOAuthProvider` accepts any PKCE client and issues tokens automatically. The MCP endpoint itself remains open (no token enforcement), so existing programmatic and Claude Desktop access is unaffected.

## Test plan
- [x] Full PKCE flow tested locally: register → authorize (302 redirect) → token (200) → MCP initialize with Bearer (200)
- [ ] Deploy to Render and add server as connector in Claude.ai — confirm tools appear and are callable
- [ ] Confirm `POST /mcp` without token still returns 200 (backward compat)
- [ ] Confirm `GET /.well-known/oauth-authorization-server` returns correct issuer URL on Render